### PR TITLE
refactor: use relevant peer deps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules

--- a/libs/index.ts
+++ b/libs/index.ts
@@ -1,0 +1,5 @@
+export * from './configs/commitlint.config'
+export * from './configs/eslint.config'
+export * from './configs/lint-staged.config'
+export * from './configs/prettier.config'
+export * from './configs/release.config'

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
         "prettier": "^3.4.2",
         "rimraf": "^6.0.1",
         "semantic-release": "^24.2.1"
+      },
+      "peerDependencies": {
+        "eslint": "^9.19.0",
+        "lint-staged": "^15.4.3",
+        "prettier": "^3.4.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Collection of toasty utils and configs used by Marshmallow Technology",
   "main": "index.js",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rimraf ./dist",
     "test": "echo \"Error: There are no tests yet\"",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
   "dependencies": {
     "typescript": "^5.7.3"
   },
+  "peerDependencies": {
+    "eslint": "^9.19.0",
+    "prettier": "^3.4.2",
+    "lint-staged": "^15.4.3"
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",
     "@commitlint/types": "^19.5.0",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,10 +3,11 @@
   "compilerOptions": {
     "rootDir": "libs",
     "baseUrl": "libs",
-    "outDir": "./dist",
-    "declaration": true,
+    "outDir": "./dist"
   },
   "exclude": [
+    "node_modules",
+    "dist",
     "release.config.js",
     "commitlint.config.ts",
     "eslint.config.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "libs",
+    "baseUrl": "libs",
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "Bundler",
@@ -9,8 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "rootDir": "libs",
-    "baseUrl": "libs",
     "declaration": true
   },
   "include": ["libs/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "rootDir": "libs",
+    "baseUrl": "libs",
+    "declaration": true
   },
   "include": ["libs/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

- deletes .npmignore and opts for files in package.json instead
- adds relevant peer deps to package.json

