### PR TITLE
Add 'secrets: inherit' to Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,3 +7,4 @@ on:
 jobs:
   auto-merge-dependabot:
     uses: marshmallow-insurance/actions-reusable-workflows/.github/workflows/auto-merge-dependabot.yml@main
+    secrets: inherit


### PR DESCRIPTION
PR generated using [multi-gitter](https://github.com/lindell/multi-gitter) from [this config file](https://github.com/marshmallow-insurance/Platform-multi-git-changes/blob/main/add-secrets-inherit/add-secrets-inherit.yml)

This PR ensures that all repos using the auto-merge Dependabot workflow correctly inherit secrets, allowing the Marshmallow-CI user token to be used for approvals.
