### PR TITLE
fix: update semantic-release workflows to use marsh ci

### DIFF
--- a/.github/workflows/shared-semantic-release-preview.yml
+++ b/.github/workflows/shared-semantic-release-preview.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install Dependencies 🔧
         run: |
           npm ci
-      - name: Configure Git 🪪
-        run: |
-          git config user.name "marshmallow-ci"
-          git config user.email "ci@marshmallow.co"
       - name: Generate preview CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: "marshmallow-ci"
+          GIT_AUTHOR_EMAIL: "ci@marshmallow.co"
+          GIT_COMMITTER_NAME: "marshmallow-ci"
+          GIT_COMMITTER_EMAIL: "ci@marshmallow.co"
         run: npx semantic-release --dry-run 

--- a/.github/workflows/shared-semantic-release.yml
+++ b/.github/workflows/shared-semantic-release.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Install Dependencies 🔧
         run: |
           npm ci
-      - name: Configure Git 🪪
-        run: |
-          git config user.name "marshmallow-ci"
-          git config user.email "ci@marshmallow.co"
       - name: Generate CHANGELOG.md & Bump & Release to NPM 🦫
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: "marshmallow-ci"
+          GIT_AUTHOR_EMAIL: "ci@marshmallow.co"
+          GIT_COMMITTER_NAME: "marshmallow-ci"
+          GIT_COMMITTER_EMAIL: "ci@marshmallow.co"
         run: npx semantic-release 


### PR DESCRIPTION
## What does this do?
<!-- 
- A short description of what the PR changes and why it's necessary
- Give the reviewers context
- Is the impact global or localised?
- Any tech debt created or discovered?
-->

- adjusts workflows to use marsh ci for git configuration
