### PR TITLE
feat(release-config): Add `next` branch and support maintenance releases

### DIFF
--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -47,7 +47,7 @@ const config = {
     {
       // Major release branches e.g. v14.x.x, v14.x equivalent to v14.0.0
       name: 'v+([0-9])?(.{+([0-9]),x}).x',
-      range: "${name.replace(/^v\\//g, '')}",
+      range: "${name.replace(/^v/g, '')}",
     },
   ],
   repositoryUrl,

--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -50,6 +50,7 @@ const config = {
       name: '(feature|fix|chore)/*',
       // The prerelease name uses a dynamic expression to replace '/' with '-'
       // Will result in something like 'crumbs-feature-name' or 'crumbs-fix-name'
+      channel: 'beta',
       prerelease: 'crumbs-${name.replace(/\\//g, "-")}',
     },
   ],

--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -39,16 +39,18 @@ const repositoryUrl = getRepositoryUrl()
 const config = {
   branches: [
     'main',
+    'next',
+    {
+      // These branches are used for patches and hotfixes of previous major or minor releases.
+      // e.g v1.x, v1.1.x, etc.
+      name: 'v+([0-9])?(.{+([0-9]),x}).x',
+      range: "${name.replace(/^v/g, '')}",
+    },
     {
       name: '(feature|fix|chore)/*',
       // The prerelease name uses a dynamic expression to replace '/' with '-'
+      // Will result in something like 'crumbs-feature-name' or 'crumbs-fix-name'
       prerelease: 'crumbs-${name.replace(/\\//g, "-")}',
-    },
-    {
-      // Major release branches e.g. v14.x.x, v14.x equivalent to v14.0.0
-      name: 'v+([0-9])?(.{+([0-9]),x}).x',
-      range: "${name.replace(/^v/g, '')}",
-      prerelease: true,
     },
   ],
   repositoryUrl,

--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -41,7 +41,7 @@ const config = {
     'main',
     'next',
     {
-      // These branches are used for patches and hotfixes of previous major or minor releases.
+      // These branches are used for patches and hotfixes of previous major versions.
       // e.g v1.x, v1.1.x, etc.
       name: 'v+([0-9])?(.{+([0-9]),x}).x',
       range: "${name.replace(/^v/g, '')}",

--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -48,6 +48,7 @@ const config = {
       // Major release branches e.g. v14.x.x, v14.x equivalent to v14.0.0
       name: 'v+([0-9])?(.{+([0-9]),x}).x',
       range: "${name.replace(/^v/g, '')}",
+      prerelease: true,
     },
   ],
   repositoryUrl,

--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -44,6 +44,11 @@ const config = {
       // The prerelease name uses a dynamic expression to replace '/' with '-'
       prerelease: 'crumbs-${name.replace(/\\//g, "-")}',
     },
+    {
+      // Major release branches e.g. v14.x.x, v14.x equivalent to v14.0.0
+      name: 'v+([0-9])?(.{+([0-9]),x}).x',
+      range: "${name.replace(/^v\\//g, '')}",
+    },
   ],
   repositoryUrl,
   plugins: [


### PR DESCRIPTION
Work to implement Introducing [Major Version Releases for Frontend Libraries](https://www.notion.so/getmarshmallow/Introducing-Major-Version-Releases-for-Frontend-Libraries-1e5c6747c73380d98fadfc98ae27cbd6?source=copy_link)

Turns out I misunderstood how we can shape our 'major version branches'. The branch version convention e.g. naming a branch `v2.0.0` won't work as that is usually reserved for maintainence releases, e.g. if you wanted to release a patch to a previous major version you would create a `v1.x.x` branch. Instead, we will take the approach of having a single `next` branch that we can use as our continuous release branch that releases future versions.

**TL;DR:** Supporting a single `next` branch for continuous future releases and, as an addition, maintenance branches as well because why not?

### Changes
- Introduce a `next` prerelease branch for new major version work.
  - Used when we want breaking changes to be available but aren't able to release to `@latest` since some times might've not migrated yet or we might want to test more before.
- Allow for maintenance branches with the `v` prefix e.g. `v1.x.x`, `v1.3.x`
- Ensure feature branch releases always publish to the static `beta` channel to avoid too many noisy transient distribution channels in the npm registry

### Next PR(s) will include:
- Introduction to continuous releases for commits to the next branch
  - Will need to implement branch protections on this one since we probably want to enforce PR review for commits to this branch. Other code repositories will have to do the same, unless we have terraforms for this?


> [!NOTE]
> Documentation around this will need to be updated, additionally we still need to clarify how to properly write a breaking change commit, because... [there's rules](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit?tab=t.0#heading=h.em2hiij8p46d)