### PR TITLE
Migrate dependabot reviewers/assignees to CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,4 @@ updates:
       time: '05:00'
       timezone: Europe/London
     open-pull-requests-limit: 99
-    reviewers:
-      - marshmallow-insurance/frontend
-    assignees:
       - marshmallow-insurance/frontend


### PR DESCRIPTION
This change migrates the deprecated dependabot `reviewers` and `assignees` to a `.github/CODEOWNERS` file:

- Extracts all team references from `reviewers` and `assignees` properties in `.github/dependabot.yml`
- Creates a new `.github/CODEOWNERS` file (if one doesn't already exist) with these teams as global code owners
- Removes the `reviewers` and `assignees` properties from the dependabot configuration

This approach centralizes code review assignments through CODEOWNERS while maintaining the same review process for dependabot PRs.

<small>PR generated using [multi-gitter](https://github.com/lindell/multi-gitter) from [this config file](https://github.com/marshmallow-insurance/Platform-multi-git-changes/blob/main/dependabot-codeowners/migrate-dependabot-to-codeowners.yml)</small>
