### PR TITLE
feat(eslint-plugin): export standalone plugin

### DIFF
--- a/libs/configs/eslint-plugin.js
+++ b/libs/configs/eslint-plugin.js
@@ -1,0 +1,13 @@
+import { noColorPropRule } from './eslint-rules/no-color-prop/no-color-prop.js'
+import { noThemeColorsRule } from './eslint-rules/no-theme-colors/no-theme-colors.js'
+
+/** @type {import('eslint').ESLint.Plugin} */
+const campfirePlugin = {
+  meta: { name: 'campfire' },
+  rules: {
+    'no-color-prop': noColorPropRule,
+    'no-theme-colors': noThemeColorsRule,
+  },
+}
+
+export default campfirePlugin

--- a/libs/configs/eslint-plugin.test.ts
+++ b/libs/configs/eslint-plugin.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import campfirePlugin from './eslint-plugin.js'
+
+describe('campfire eslint plugin', () => {
+  it('exposes the campfire namespace via meta.name', () => {
+    expect(campfirePlugin.meta?.name).toBe('campfire')
+  })
+
+  it('exports the no-color-prop and no-theme-colors rules', () => {
+    expect(Object.keys(campfirePlugin.rules ?? {}).sort()).toEqual([
+      'no-color-prop',
+      'no-theme-colors',
+    ])
+  })
+
+  it('each rule is a runnable rule object', () => {
+    for (const rule of Object.values(campfirePlugin.rules ?? {})) {
+      expect(rule).toBeTypeOf('object')
+      expect(typeof (rule as { create?: unknown }).create).toBe('function')
+    }
+  })
+})

--- a/libs/configs/eslint.config.js
+++ b/libs/configs/eslint.config.js
@@ -2,15 +2,7 @@ import typescriptEslintPlugin from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 
-import { noColorPropRule } from './eslint-rules/no-color-prop/no-color-prop.js'
-import { noThemeColorsRule } from './eslint-rules/no-theme-colors/no-theme-colors.js'
-
-const campfireEslintPlugin = {
-  rules: {
-    'no-color-prop': noColorPropRule,
-    'no-theme-colors': noThemeColorsRule,
-  },
-}
+import campfirePlugin from './eslint-plugin.js'
 
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
@@ -25,7 +17,7 @@ const config = [
     },
     plugins: {
       '@typescript-eslint': typescriptEslintPlugin,
-      campfire: campfireEslintPlugin,
+      campfire: campfirePlugin,
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn', // Warns on use of 'any'


### PR DESCRIPTION
## What does this do?

Exposes the campfire custom ESLint rules (`no-color-prop`, `no-theme-colors`) as a standalone plugin importable via `@mrshmllw/campfire/configs/eslint-plugin`.

Until now the rules were wired up inline inside the bundled flat ESLint config (`libs/configs/eslint.config.js`), so consumers could only get them by extending the entire config. Repos that don't use ESLint — `uk-auto-agent-portal-www` is on **oxlint**, others may move to biome — had to reach into deep `dist/configs/eslint-rules/*/*.js` paths to register the rules. This PR gives every linter a clean public entry point.

The existing flat config now imports the plugin from the same module, so the rule list lives in one place and can't drift between the two surfaces. The package's `exports` map already covers the new file via the existing `./configs/*` wildcard, so no `package.json` change is needed.

Impact is localised — no change to existing ESLint consumers (the bundled config still ships the same plugin under the same `campfire/` namespace and rule names).

## Relevant tickets / Documentation

[RET-1469](https://linear.app/marshmallow/issue/RET-1469/agent-portal-campfire-create-exportable-eslint-plugin-in-campfire) — closes the campfire-side TODO. Follow-up: replace `oxlint-campfire-plugin.mjs` in `uk-auto-agent-portal-www` with the new clean import once this is released.

## Testing

- New `libs/configs/eslint-plugin.test.ts` asserts plugin shape: `meta.name === 'campfire'`, exact rule keys, and that each rule is a runnable rule object with a `create` function.
- The existing rule-behaviour tests (`no-color-prop.test.ts`, `no-theme-colors.test.ts`) continue to cover the rule logic itself — unchanged.
- Verified locally: `npm run check-types`, `npm test` (39/39 pass), `npm run build` emits `dist/configs/eslint-plugin.{js,d.ts}`, and `node -e "import('./dist/configs/eslint-plugin.js')..."` resolves and prints the expected `{name, rules}`.