### PR TITLE
chore(peer-deps): drop upper-bound caps from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,19 +30,19 @@
     "dist"
   ],
   "peerDependencies": {
-    "@commitlint/cli": "^20",
+    "@commitlint/cli": ">=20",
     "@commitlint/types": ">=20",
     "conventional-changelog-conventionalcommits": ">=9",
     "@semantic-release/changelog": ">=6",
     "@semantic-release/git": ">=10",
     "@typescript-eslint/eslint-plugin": ">=8",
     "@typescript-eslint/parser": ">=8",
-    "eslint": "^9 || ^10",
-    "eslint-config-prettier": "^9 || >=10",
-    "eslint-plugin-prettier": "^4 || >=5",
-    "husky": "^9",
-    "lint-staged": "^15 || ^16",
-    "prettier": "^3",
+    "eslint": ">=9",
+    "eslint-config-prettier": ">=9",
+    "eslint-plugin-prettier": ">=4",
+    "husky": ">=9",
+    "lint-staged": ">=15",
+    "prettier": ">=3",
     "semantic-release": ">=25"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## What does this do?

Several peer dependencies were pinned to specific majors via caret ranges, which forces consumers to wait on a campfire release whenever an upstream tool ships a new major — even when nothing in campfire's usage would actually break.

Switched these to `>=` minimums, matching the style already used for the rest of the peer deps. Consumers can now adopt new majors of tools like `lint-staged`, `eslint`, `prettier`, `husky`, and `@commitlint/cli` without needing a coordinated campfire bump.

Affected peer deps:

- `@commitlint/cli`: `^20` → `>=20`
- `eslint`: `^9 || ^10` → `>=9`
- `eslint-config-prettier`: `^9 || >=10` → `>=9`
- `eslint-plugin-prettier`: `^4 || >=5` → `>=4`
- `husky`: `^9` → `>=9`
- `lint-staged`: `^15 || ^16` → `>=15`
- `prettier`: `^3` → `>=3`

Impact is localised to install-time peer resolution for consumers. No code or runtime behaviour changes.

## Relevant tickets / Documentation

n/a

## Testing

No test changes — this is a manifest-only change. CI on this branch exercises the dev-dependency versions which sit within the new ranges.