### PR TITLE
fix(release): disable linkReferences to prevent crash on Dependabot HTML commit bodies

### DIFF
--- a/libs/configs/release.config.js
+++ b/libs/configs/release.config.js
@@ -133,6 +133,12 @@ const config = {
             { type: '*', section: 'Others' },
           ],
         },
+        // Dependabot commit bodies contain raw HTML from GitHub release notes.
+        // Disabling link references prevents conventional-changelog from trying
+        // to process that HTML when generating release notes.
+        writerOpts: {
+          linkReferences: false,
+        },
       },
     ],
     [


### PR DESCRIPTION
## Problem

When running `Bump and Publish` from a feature branch, `semantic-release` fails at the `generateNotes` step with an `AggregateError`. The root cause is that Dependabot injects raw GitHub release-notes HTML into commit bodies, e.g.:

```html
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="...">typescript-eslint's releases</a>.</em></p>
<blockquote>
<h2>v8.62.0</h2>
...
```

`conventional-changelog`'s link-reference processing attempts to parse and linkify content in commit bodies. It chokes on this HTML, crashing `generateNotes` before any release notes are produced.

## Fix

Set `writerOpts: { linkReferences: false }` in the `@semantic-release/release-notes-generator` plugin config. This disables the link-reference processing step entirely, which is safe since release notes are rendered as plain markdown and do not need resolved hyperlinks for commit/PR references.

## Impact

- All repos consuming `@mrshmllw/campfire`'s `release.config` benefit from this fix
- No change to release note content — `chore(npm-dep)` commits are already `hidden: true` and excluded from rendered output