### PR TITLE
fix(ci): install non-bundled semantic-release plugins in shared release

### DIFF
--- a/.github/workflows/shared-semantic-release.yml
+++ b/.github/workflows/shared-semantic-release.yml
@@ -59,4 +59,16 @@ jobs:
           GIT_AUTHOR_EMAIL: "ci@marshmallow.co"
           GIT_COMMITTER_NAME: "marshmallow-ci"
           GIT_COMMITTER_EMAIL: "ci@marshmallow.co"
-        run: npx semantic-release 
+        # semantic-release bundles commit-analyzer, release-notes-generator, npm and
+        # github, but NOT changelog/git or the conventionalcommits preset. Consumers
+        # only install campfire's `dependencies` (these plugins are dev/peer deps), so
+        # bare `npx semantic-release` resolves a fresh copy without them and fails on
+        # `main` with "Cannot find module '@semantic-release/changelog'". Install the
+        # non-bundled plugins explicitly, pinned to campfire's declared ranges.
+        run: >
+          npx
+          -p semantic-release@^25
+          -p @semantic-release/changelog@^6
+          -p @semantic-release/git@^10
+          -p conventional-changelog-conventionalcommits@^9
+          semantic-release


### PR DESCRIPTION
## What does this do?

Fixes the shared `shared-semantic-release` workflow, which has failed on **every consumer's `main` release since ~2026-05-08** with `Cannot find module '@semantic-release/changelog'`.

**Root cause:** the release step runs bare `npx semantic-release`, which installs semantic-release plus only its *bundled* plugins (`commit-analyzer`, `release-notes-generator`, `npm`, `github`). The shared config (`libs/configs/release.config.js`) additionally requires `@semantic-release/changelog` and `@semantic-release/git` — appended on non-prerelease (main-line) releases — and the `conventionalcommits` preset. Those are declared as campfire **dev/peer dependencies**, so consumer repos (which install only campfire's `dependencies`) never get them, and the npx-resolved semantic-release can't load them. Prerelease branches skip the changelog/git plugins, which is why feature-branch publishes still work and only `main` fails.

**Fix:** install the non-bundled plugins explicitly in the `npx` invocation, pinned to campfire's declared ranges.

**Impact:** global — unblocks main-line NPM publishes for all repos consuming this workflow (e.g. `smores-react`, whose last published `latest` is stuck at `16.0.3`).

## Relevant tickets / Documentation

Surfaced while investigating why merged `smores-react` changes weren't reaching NPM (PRs [#5070](https://github.com/marshmallow-insurance/smores-react/pull/5070), [#5072](https://github.com/marshmallow-insurance/smores-react/pull/5072)). Both built green but the post-merge publish job failed on this.

## Testing

- [x] YAML parses; the folded `run` resolves to a single `npx -p … semantic-release` command
- [ ] Merge to campfire `main`, then confirm the next `smores-react` main merge publishes a new version to NPM (first real end-to-end signal — this workflow only runs from consumer repos)

<!-- No local way to fully exercise a shared reusable workflow; the publish path is verified by the next consumer release. -->