### PR TITLE
fix(ci): stop npx -p env leak breaking consumer lifecycle scripts

### DIFF
--- a/.github/workflows/shared-semantic-release.yml
+++ b/.github/workflows/shared-semantic-release.yml
@@ -65,10 +65,12 @@ jobs:
         # bare `npx semantic-release` resolves a fresh copy without them and fails on
         # `main` with "Cannot find module '@semantic-release/changelog'". Install the
         # non-bundled plugins explicitly, pinned to campfire's declared ranges.
-        run: >
-          npx
-          -p semantic-release@^25
-          -p @semantic-release/changelog@^6
-          -p @semantic-release/git@^10
-          -p conventional-changelog-conventionalcommits@^9
-          semantic-release
+        #
+        # Install-then-run rather than `npx -p ...`: the -p flags export
+        # npm_config_package to every child process, so any nested `npx <pkg>` in a
+        # consumer's lifecycle scripts (e.g. prepack) stops resolving <pkg> and hands
+        # it to sh as a literal command (broke smores-internal's 4.3.2 npm publish
+        # with "@tailwindcss/cli: not found").
+        run: |
+          npm install --no-save semantic-release@^25 @semantic-release/changelog@^6 @semantic-release/git@^10 conventional-changelog-conventionalcommits@^9
+          ./node_modules/.bin/semantic-release


### PR DESCRIPTION
## What

Changes the shared semantic-release step from `npx -p <plugins> semantic-release` to `npm install --no-save <plugins>` + running the local bin.

## Why

#516 fixed the missing-plugin problem but introduced a subtle env leak: `npx -p` exports `npm_config_package` to **every child process** of semantic-release. Any consumer whose npm lifecycle scripts (prepack/prepare) use a nested `npx <pkg>` then breaks — npm treats `<pkg>` as a bare shell command inside the `-p` package set instead of resolving it.

First casualty: smores-internal's 4.3.2 release — `sh: 1: @tailwindcss/cli: not found` during prepack's CSS build — which left v4.3.2 tagged in git but never published to npm. Any consumer calling `npx` for a package whose bin name differs from its package name is exposed.

Reproducible locally in any repo with @tailwindcss/cli installed:
```
$ npx @tailwindcss/cli --help          # works
$ env npm_config_package='semantic-release@^25' npx @tailwindcss/cli --help
sh: @tailwindcss/cli: No such file or directory
```

`npm install --no-save` gives the same plugin-resolution guarantees (pinned to campfire's declared ranges, resolved into the consumer's node_modules) without mutating ambient npm env, and doesn't touch package.json or the lockfile.

smores-internal has also hardened its own build script (smores-internal#445), but other consumers of this workflow remain exposed until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)