### PR TITLE
ci: bump shared actions off deprecated node20 runtime

### DIFF
--- a/.github/actions/run-fossa-analysis/action.yml
+++ b/.github/actions/run-fossa-analysis/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Run Fossa Dependency Analysis 🐛
-      uses: fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94
+      uses: fossas/fossa-action@8dea2e348349fad66e838ce0b365b044c6bf2011 # v2.0.0
       with:
         api-key: ${{ inputs.api-key }}
 

--- a/.github/actions/setup-node-project/action.yml
+++ b/.github/actions/setup-node-project/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:  
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         cache: 'npm'
         package-manager-cache: true

--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (to access local action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: marshmallow-insurance/campfire/.github/actions/setup-node-project@main
       - name: Run Check Types
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           npm run build
       - uses: marshmallow-insurance/campfire/.github/actions/run-fossa-analysis@main
-        if: secrets.FOSSA_API_KEY != ''
+        if: env.FOSSA_API_KEY != ''
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (to access local action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - uses: marshmallow-insurance/campfire/.github/actions/setup-node-project@main
 

--- a/.github/workflows/shared-auto-merge-dependabot.yml
+++ b/.github/workflows/shared-auto-merge-dependabot.yml
@@ -24,7 +24,7 @@ jobs:
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
 
       - name: Approve a PR
-        if: steps.should-run.outputs.should_run == 'true' && secrets.AUTO_MERGE_DEPENDABOT_PR != ''
+        if: steps.should-run.outputs.should_run == 'true' && env.GH_TOKEN != ''
         run: |
           CURRENT_DECISION="$(gh pr view "$PR_URL" --json reviewDecision -q '.reviewDecision')"
           if [ "$CURRENT_DECISION" != "APPROVED" ]; then

--- a/.github/workflows/shared-semantic-release-preview.yml
+++ b/.github/workflows/shared-semantic-release-preview.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.MARSHMALLOW_CI_APP_ID }}
           private-key: ${{ secrets.MARSHMALLOW_CI_APP_PRIVATE_KEY }}
       
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/shared-semantic-release.yml
+++ b/.github/workflows/shared-semantic-release.yml
@@ -35,14 +35,14 @@ jobs:
           fi
       
       - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.MARSHMALLOW_CI_APP_ID }}
           private-key: ${{ secrets.MARSHMALLOW_CI_APP_PRIVATE_KEY }}
       
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false


### PR DESCRIPTION
## What does this do?

GitHub deprecated the Node 20 runtime for Actions (Sept 2025) — every job now prints "Node 20 is being deprecated... running with Node 24 by default" when it hits an action whose `action.yml` still declares `using: node20`. Found and fixed while working on [RET-2280](https://linear.app/marshmallow/issue/RET-2280/smores-react-ci-speedup-follow-up-for-pull-requestyml) in smores-react (see [smores-react#5109](https://github.com/marshmallow-insurance/smores-react/pull/5109)) — `setup-node-project` here is the *shared* action every consumer repo pulls, so the warning was hitting all of them, not just campfire's own CI.

- `actions/checkout@v4` → `v7` (4 places: `pull_request.yml`, `merge_main.yml`, both `shared-semantic-release*.yml`)
- `actions/setup-node@v4` → `v7` in `setup-node-project/action.yml` — the one that matters most, since it propagates to every consumer
- `actions/create-github-app-token@v1` → `v3` in both semantic-release shared workflows
- `fossas/fossa-action` bumped from a v1-era pinned commit to `v2.0.0` (pinned by commit SHA, matching the existing style) — same node20 issue, its only functional change per the release notes is the runtime bump
- Checked each action's own changelog for breaking changes between these majors: none affect how they're used here (checkout's `persist-credentials` handling changed in v6 but we don't persist credentials anywhere; create-github-app-token's v2/v3 breaking changes are about snake_case inputs and custom proxy handling, neither used here)

Also added a `concurrency` group to `pull_request.yml` so a new push cancels the in-flight run for that PR — campfire's own CI didn't have this yet, matching what smores-react's PR workflow already does. Since this workflow is also called via `workflow_call`, used `${{ github.workflow }}-${{ github.ref }}` for the group key rather than `github.event.pull_request.number`, since the latter isn't populated in the `workflow_call` context.

**Unrelated bug found and fixed along the way:** `pull_request.yml` and `shared-auto-merge-dependabot.yml` both had a step-level `if:` referencing the `secrets` context directly (e.g. `if: secrets.FOSSA_API_KEY != ''`), which GitHub Actions doesn't allow — `secrets` isn't in the set of contexts permitted in step `if:` conditions. This made both workflows fail to even parse ("workflow file issue", zero jobs created). Confirmed pre-existing on `main` (its last `pull_request.yml` run already failed the same way) and confirmed org-wide impact: `shared-auto-merge-dependabot.yml` is called by every consumer's dependabot automation, and smores-react's own `auto-merge-dependabot.yml` run is failing identically right now. Fixed by routing the secret through that step's own `env:` and checking `env.X` instead, which is an allowed context.

## Verification

- `pull_request.yml` now runs and passes on this branch (previously failed to parse at all) — confirms both the `checkout@v7` bump (inline in the workflow) and the `secrets`-in-`if:` fix.
- Because `setup-node-project` and `run-fossa-analysis` are referenced via `@main` from this same workflow, the `setup-node@v7` and `fossa-action@v2.0.0` bumps inside those composite actions can't be exercised by a PR-time run against this branch — they only take effect for every consumer (including this repo's own CI) once merged to `main`. The equivalent `setup-node@v7` bump was already verified end-to-end in smores-react's PR (marshmallow-insurance/smores-react#5109), including confirming the deprecation warning disappears from real job logs.
- Ran `actionlint` across all workflow files after each change; clean.

## Relevant tickets / Documentation

[RET-2280](https://linear.app/marshmallow/issue/RET-2280/smores-react-ci-speedup-follow-up-for-pull-requestyml)