### PR TITLE
fix(ci): pin fossa-action back to the allowlisted SHA

### DIFF
--- a/.github/actions/run-fossa-analysis/action.yml
+++ b/.github/actions/run-fossa-analysis/action.yml
@@ -3,17 +3,17 @@ description: 'Runs Fossa dependency analysis'
 
 inputs:
   api-key:
-    description: 'Fossa API key. When empty the analysis is skipped.'
-    required: false
+    description: 'Fossa API key'
+    required: true
 
 runs:
   using: 'composite'
   steps:
-    # Dependabot PRs (and forks) can't read repo secrets, so the key arrives empty
-    # and fossa-action hard-crashes. Skip instead — merge_main still scans main.
     - name: Run Fossa Dependency Analysis 🐛
-      if: inputs.api-key != ''
-      uses: fossas/fossa-action@8dea2e348349fad66e838ce0b365b044c6bf2011 # v2.0.0
+      # Pinned to this SHA because it is the only fossa-action revision on the org's
+      # allowed-actions list. Bumping (e.g. v2.0.0, 8dea2e34) fails every run at
+      # action-download time. Get the new SHA allowlisted first, then bump.
+      uses: fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94
       with:
         api-key: ${{ inputs.api-key }}
 

--- a/.github/actions/run-fossa-analysis/action.yml
+++ b/.github/actions/run-fossa-analysis/action.yml
@@ -3,13 +3,16 @@ description: 'Runs Fossa dependency analysis'
 
 inputs:
   api-key:
-    description: 'Fossa API key'
-    required: true
+    description: 'Fossa API key. When empty the analysis is skipped.'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    # Dependabot PRs (and forks) can't read repo secrets, so the key arrives empty
+    # and fossa-action hard-crashes. Skip instead — merge_main still scans main.
     - name: Run Fossa Dependency Analysis 🐛
+      if: inputs.api-key != ''
       uses: fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94
       with:
         api-key: ${{ inputs.api-key }}


### PR DESCRIPTION
## Context

All CI in this repo is red — `Merge Main`, `Bump and Publish`, and every open PR (e.g. #496, #504, #518). Runs fail in ~10s at `Set up job` / `Prepare all required actions`, before a single step executes:

```
The action fossas/fossa-action@8dea2e348349fad66e838ce0b365b044c6bf2011 is not allowed in
marshmallow-insurance/campfire because all actions must be from a repository owned by your
enterprise, created by GitHub, or match one of the patterns: ...
fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94, ...
```

#537 bumped fossa-action to v2.0.0 to get off the deprecated node20 runtime. The other actions in that PR are all `actions/*`, which are GitHub-owned and permitted unconditionally — but `fossas/fossa-action` is third-party and the org allowlist pins one exact SHA, the v1-era `93a52ecf`. The new SHA isn't on the list, so the allowlist check rejects it.

This is an allowlist check at action-download time, so it can't be worked around with an `if:` condition on the step — the run fails before conditions are evaluated.

## Changes

Pin back to the allowlisted SHA, with a comment so the next person doesn't re-bump it into the same wall.

Trade-off: fossa goes back to emitting the node20 deprecation warning that #537 was clearing. A warning is better than every workflow in the repo failing. The follow-up is to get `8dea2e34` (v2.0.0) added to the org's allowed-actions list, then re-apply the bump.

## Note on #496

#496 was the PR that surfaced this. Its visible failure was a month-old run with a different cause — `Input required and not supplied: api-key`, because Dependabot runs can't read repo secrets so `FOSSA_API_KEY` arrived empty. #537 already fixed that one by guarding the step with `env.FOSSA_API_KEY != ''`, so no change is needed here for it. Once this merges, #496 needs a re-run, and it also has a `package-lock.json` conflict to clear (`@dependabot recreate`).