### PR TITLE
chore(RET-2293): drop `@typescript-eslint` dependency from ESLint rules

### DIFF
--- a/libs/configs/eslint-plugin.test.ts
+++ b/libs/configs/eslint-plugin.test.ts
@@ -1,5 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { Linter } from 'eslint'
 import { describe, expect, it } from 'vitest'
 import campfirePlugin from './eslint-plugin.js'
+
+const RULE_SOURCES = [
+  './eslint-rules/no-color-prop/no-color-prop.js',
+  './eslint-rules/no-theme-colors/no-theme-colors.js',
+]
+
+const lintConfig = (rules: Linter.RulesRecord): Linter.Config => ({
+  plugins: { campfire: campfirePlugin },
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+    },
+  },
+  rules,
+})
 
 describe('campfire eslint plugin', () => {
   it('exposes the campfire namespace via meta.name', () => {
@@ -18,5 +38,58 @@ describe('campfire eslint plugin', () => {
       expect(rule).toBeTypeOf('object')
       expect(typeof (rule as { create?: unknown }).create).toBe('function')
     }
+  })
+
+  it.each(RULE_SOURCES)('%s imports no @typescript-eslint package', (src) => {
+    const source = readFileSync(
+      fileURLToPath(new URL(src, import.meta.url)),
+      'utf8',
+    )
+    expect(source).not.toContain('@typescript-eslint')
+  })
+
+  describe('loaded into ESLint as a plugin', () => {
+    const linter = new Linter()
+
+    it('reports no-theme-colors through the plugin namespace', () => {
+      const messages = linter.verify(
+        'const c = theme.colors.liquorice',
+        lintConfig({ 'campfire/no-theme-colors': 'error' }),
+      )
+
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({
+        ruleId: 'campfire/no-theme-colors',
+        messageId: 'noThemeColors',
+        severity: 2,
+      })
+    })
+
+    it('applies the no-color-prop autofix through the plugin namespace', () => {
+      const { output, fixed } = linter.verifyAndFix(
+        '<Loader color="lollipop" />',
+        lintConfig({ 'campfire/no-color-prop': 'error' }),
+      )
+
+      expect(fixed).toBe(true)
+      expect(output).toBe('<Loader color="color.surface.brand.400" />')
+    })
+
+    it('honours rule options passed through ESLint config', () => {
+      const code = '<Loader name="cream" />'
+
+      expect(
+        linter.verify(code, lintConfig({ 'campfire/no-color-prop': 'error' })),
+      ).toHaveLength(0)
+
+      expect(
+        linter.verify(
+          code,
+          lintConfig({
+            'campfire/no-color-prop': ['error', { strictMode: true }],
+          }),
+        ),
+      ).toHaveLength(1)
+    })
   })
 })

--- a/libs/configs/eslint-plugin.test.ts
+++ b/libs/configs/eslint-plugin.test.ts
@@ -1,13 +1,6 @@
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { Linter } from 'eslint'
 import { describe, expect, it } from 'vitest'
 import campfirePlugin from './eslint-plugin.js'
-
-const RULE_SOURCES = [
-  './eslint-rules/no-color-prop/no-color-prop.js',
-  './eslint-rules/no-theme-colors/no-theme-colors.js',
-]
 
 const lintConfig = (rules: Linter.RulesRecord): Linter.Config => ({
   plugins: { campfire: campfirePlugin },
@@ -38,14 +31,6 @@ describe('campfire eslint plugin', () => {
       expect(rule).toBeTypeOf('object')
       expect(typeof (rule as { create?: unknown }).create).toBe('function')
     }
-  })
-
-  it.each(RULE_SOURCES)('%s imports no @typescript-eslint package', (src) => {
-    const source = readFileSync(
-      fileURLToPath(new URL(src, import.meta.url)),
-      'utf8',
-    )
-    expect(source).not.toContain('@typescript-eslint')
   })
 
   describe('loaded into ESLint as a plugin', () => {

--- a/libs/configs/eslint-rules/no-color-prop/no-color-prop.js
+++ b/libs/configs/eslint-rules/no-color-prop/no-color-prop.js
@@ -1,5 +1,3 @@
-import { ESLintUtils } from '@typescript-eslint/utils'
-
 const COLOR_MAP = {
   fairyFloss: 'color.surface.brand.100',
   bubblegum: 'color.surface.brand.200',
@@ -77,8 +75,8 @@ const DEFAULT_COLOR_PROPS = new Set([
   'activeColor',
 ])
 
-export const noColorPropRule = ESLintUtils.RuleCreator((name) => `${name}`)({
-  name: 'no-color-prop',
+/** @type {import('eslint').Rule.RuleModule} */
+export const noColorPropRule = {
   meta: {
     type: 'problem',
     fixable: 'code',
@@ -103,7 +101,6 @@ export const noColorPropRule = ESLintUtils.RuleCreator((name) => `${name}`)({
       },
     ],
   },
-  defaultOptions: [{}],
   create(context) {
     const options = context.options[0] || {}
     const additionalColorProps = new Set(options.additionalColorProps || [])
@@ -296,4 +293,4 @@ export const noColorPropRule = ESLintUtils.RuleCreator((name) => `${name}`)({
       },
     }
   },
-})
+}

--- a/libs/configs/eslint-rules/no-color-prop/no-color-prop.test.ts
+++ b/libs/configs/eslint-rules/no-color-prop/no-color-prop.test.ts
@@ -1,6 +1,5 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester } from 'eslint'
 import { noColorPropRule } from './no-color-prop'
-import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -62,140 +61,121 @@ ruleTester.run('no-color-prop', noColorPropRule, {
       name: 'old color usage with color prop',
       code: '<Loader height="200px" color="lollipop" />',
       output: '<Loader height="200px" color="color.surface.brand.400" />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'old color usage with any prop name',
       code: '<Loader height="200px" backgroundColor="marshmallowPink" />',
       output:
         '<Loader height="200px" backgroundColor="color.surface.brand.300" />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'ambiguous name in color context',
       code: '<Loader color="cream" />',
       output: '<Loader color="color.surface.base.000" />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'object property with legacy color',
       code: 'const obj = { tagText: "liquorice" }',
       output: 'const obj = { tagText: "color.text.base" }',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.Property }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'variable declarator with legacy color',
       code: 'const c = "liquorice"',
       output: 'const c = "color.text.base"',
-      errors: [
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.VariableDeclarator },
-      ],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'strictMode flags ambiguous name everywhere',
       code: '<Loader name="cream" />',
       output: '<Loader name="color.surface.base.000" />',
       options: [{ strictMode: true }],
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'additionalColorProps triggers detection for ambiguous name',
       code: '<Loader label="mint" />',
       output: '<Loader label="color.feedback.positive.100" />',
       options: [{ additionalColorProps: ['label'] }],
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'single quote preservation',
       code: "<Loader color='lollipop' />",
       output: "<Loader color='color.surface.brand.400' />",
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'double quote preservation',
       code: '<Loader color="lollipop" />',
       output: '<Loader color="color.surface.brand.400" />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'expression container referencing variable with non-ambiguous legacy color',
       code: 'const myColor = "lollipop"; const el = <Loader color={myColor} />',
       output:
         'const myColor = "color.surface.brand.400"; const el = <Loader color={myColor} />',
-      errors: [
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.VariableDeclarator },
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute },
-      ],
+      errors: [{ messageId: 'noColorProp' }, { messageId: 'noColorProp' }],
     },
     {
       name: 'expression container referencing variable with ambiguous color in color prop',
       code: 'const x = "cream"; const el = <Loader color={x} />',
       output:
         'const x = "color.surface.base.000"; const el = <Loader color={x} />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'non-ambiguous color in non-color prop via variable',
       code: 'const myVar = "lollipop"; const el = <Loader name={myVar} />',
       output:
         'const myVar = "color.surface.brand.400"; const el = <Loader name={myVar} />',
-      errors: [
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.VariableDeclarator },
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute },
-      ],
+      errors: [{ messageId: 'noColorProp' }, { messageId: 'noColorProp' }],
     },
     {
       name: 'ternary expression with legacy colors in both branches',
       code: '<IconStrict backgroundColor={flag ? "apple" : "strawberry"} />',
       output:
         '<IconStrict backgroundColor={flag ? "color.feedback.positive.200" : "color.feedback.negative.200"} />',
-      errors: [
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute },
-        { messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute },
-      ],
+      errors: [{ messageId: 'noColorProp' }, { messageId: 'noColorProp' }],
     },
     {
       name: 'ternary expression with legacy color in one branch only',
       code: '<IconStrict iconColor={flag ? "cream" : "other"} />',
       output:
         '<IconStrict iconColor={flag ? "color.surface.base.000" : "other"} />',
-      errors: [{ messageId: 'noColorProp', type: AST_NODE_TYPES.JSXAttribute }],
+      errors: [{ messageId: 'noColorProp' }],
     },
     {
       name: 'theme.colors in styled-components callback',
       code: 'const X = styled.div`color: ${(props) => props.theme.colors.macaroon};`',
       output:
         'const X = styled.div`color: ${(props) => props.theme.color.illustration.accent2[100]};`',
-      errors: [
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-      ],
+      errors: [{ messageId: 'noColorMember' }],
     },
     {
       name: 'theme.colors in styled-components ternary callback',
       code: "const X = styled.div`bg: ${(props) => (props.on ? props.theme.colors.macaroon : 'transparent')};`",
       output:
         "const X = styled.div`bg: ${(props) => (props.on ? props.theme.color.illustration.accent2[100] : 'transparent')};`",
-      errors: [
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-      ],
+      errors: [{ messageId: 'noColorMember' }],
     },
     {
       name: 'destructured theme.colors in styled-components callback',
       code: 'const X = styled.div`color: ${({ theme }) => theme.colors.liquorice};`',
       output:
         'const X = styled.div`color: ${({ theme }) => theme.color.text.base};`',
-      errors: [
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-      ],
+      errors: [{ messageId: 'noColorMember' }],
     },
     {
       name: 'direct theme.colors in template wraps with arrow function',
       code: 'const X = styled.div`background-color: ${theme.colors.macaroon};`',
       output:
         'const X = styled.div`background-color: ${({theme}) => theme.color.illustration.accent2[100]};`',
-      errors: [
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-      ],
+      errors: [{ messageId: 'noColorMember' }],
     },
     {
       name: 'multiple theme.colors in template with mixed references',
@@ -207,10 +187,7 @@ ruleTester.run('no-color-prop', noColorPropRule, {
               background-color: \${({theme}) => theme.color.surface.base['000']};
               border: 2px solid \${({theme}) => theme.color.illustration.neutral[300]};
             \``,
-      errors: [
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-        { messageId: 'noColorMember', type: AST_NODE_TYPES.MemberExpression },
-      ],
+      errors: [{ messageId: 'noColorMember' }, { messageId: 'noColorMember' }],
     },
   ],
 })

--- a/libs/configs/eslint-rules/no-theme-colors/no-theme-colors.js
+++ b/libs/configs/eslint-rules/no-theme-colors/no-theme-colors.js
@@ -1,7 +1,5 @@
-import { ESLintUtils } from '@typescript-eslint/utils'
-
-export const noThemeColorsRule = ESLintUtils.RuleCreator((name) => `${name}`)({
-  name: 'no-theme-colors',
+/** @type {import('eslint').Rule.RuleModule} */
+export const noThemeColorsRule = {
   meta: {
     type: 'problem',
     docs: {
@@ -13,7 +11,6 @@ export const noThemeColorsRule = ESLintUtils.RuleCreator((name) => `${name}`)({
     },
     schema: [],
   },
-  defaultOptions: [],
   create(context) {
     return {
       MemberExpression(node) {
@@ -28,4 +25,4 @@ export const noThemeColorsRule = ESLintUtils.RuleCreator((name) => `${name}`)({
       },
     }
   },
-})
+}

--- a/libs/configs/eslint-rules/no-theme-colors/no-theme-colors.test.ts
+++ b/libs/configs/eslint-rules/no-theme-colors/no-theme-colors.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester } from 'eslint'
 import { noThemeColorsRule } from './no-theme-colors'
 
 const ruleTester = new RuleTester({

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@semantic-release/git": "^11.0.1",
         "@typescript-eslint/eslint-plugin": "^8.47.0",
         "@typescript-eslint/parser": "^8.47.0",
-        "@typescript-eslint/rule-tester": "^8.47.0",
-        "@typescript-eslint/utils": "^8.49.0",
         "concurrently": "^10.0.4",
         "conventional-changelog-conventionalcommits": "^10.2.1",
         "eslint": "^10.0.3",
@@ -1788,57 +1786,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       }
-    },
-    "node_modules/@typescript-eslint/rule-tester": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.67.0.tgz",
-      "integrity": "sha512-aOPA7+XgoRe4idCQZH9V1+ObHW6wslSp/GWwXoRwsTFUW1AZnHVvcnCFvQwTUdDtOhzwT3F/G2nOls7UuiOBiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/parser": "8.67.0",
-        "@typescript-eslint/typescript-estree": "8.67.0",
-        "@typescript-eslint/utils": "8.67.0",
-        "ajv": "^6.12.6",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "4.6.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/rule-tester/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@typescript-eslint/rule-tester/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.67.0",
@@ -4898,13 +4845,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -96,8 +96,6 @@
     "@semantic-release/git": "^11.0.1",
     "@typescript-eslint/eslint-plugin": "^8.47.0",
     "@typescript-eslint/parser": "^8.47.0",
-    "@typescript-eslint/rule-tester": "^8.47.0",
-    "@typescript-eslint/utils": "^8.49.0",
     "concurrently": "^10.0.4",
     "conventional-changelog-conventionalcommits": "^10.2.1",
     "eslint": "^10.0.3",


### PR DESCRIPTION
## What does this do?

`@typescript-eslint/utils` depends on the TypeScript compiler API, which TypeScript 7 does not yet expose. Campfire's rules imported it purely to call `ESLintUtils.RuleCreator` as a rule factory — neither rule touches the type-checker. Because the rules ship as untranspiled ESM, that import made `@typescript-eslint/utils` a de-facto runtime requirement for every consumer of the plugin despite only being declared as a devDependency, which is what currently blocks AP-www from moving to TS7 or oxlint.

**Rule definitions**
- Both rules are now plain `Rule.RuleModule` objects, typed via a JSDoc annotation against the types ESLint already ships — typing is preserved with no replacement dependency
- `defaultOptions` dropped; it was inert, as `no-color-prop` already defaults through `context.options[0] || {}`

**Test harness**
- Moved to ESLint's built-in `RuleTester`, which also removes `@typescript-eslint/rule-tester`. This was forced rather than opportunistic: `tsc` rejects a native ESLint `RuleModule` being passed to the typescript-eslint tester

| Removed from `package.json` | Was used for |
|---|---|
| `@typescript-eslint/utils` | `RuleCreator`, `AST_NODE_TYPES` |
| `@typescript-eslint/rule-tester` | `RuleTester` in both rule test suites |

Rule behaviour and autofix output are unchanged.

**Scope / tech debt discovered**

`libs/configs/eslint.config.js` still imports `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`. That is a separate consumer path — the shared ESLint config, declared as optional peers — and is deliberately untouched here. It will need revisiting if consumers move fully to oxlint.

## Relevant tickets / Documentation

Origin thread: https://eatmarshmallows.slack.com/archives/CG7VD0QMA/p1786524306739909

Closes [RET-2293](https://linear.app/marshmallow/issue/RET-2293)

## Testing

Suite grows 39 → 42. `libs/configs/eslint-plugin.test.ts` previously asserted only the plugin's shape, so it now also loads the plugin into ESLint's own `Linter` and verifies reporting, autofix output, and rule options resolving through the `campfire/*` namespace — the path a consumer actually exercises, and the one the rule-level suites don't cover.

Mutation-checked: breaking the rule predicate fails the lint assertion.

One deliberate reduction — ESLint 10's `RuleTester` no longer accepts `type` in error assertions, so those were removed. `messageId` and autofix `output` still cover the same cases.

Verified with `npm run test`, `npm run check-tsc`, `npm run lint`, and a `npm run build` confirming no `@typescript-eslint` import survives into `dist/configs/eslint-rules/**`.
